### PR TITLE
Add some additional metrics to CSV output

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ If the application does not run you may need to install the [Microsoft Visual C+
 
 ### What info does it parse?
 For each file it parses as much as it can find of the following (I imagine I'm not the only one who's had a plot interrupted):
+* Tmp Directory 
+* Log Filename 
+* Plot ID 
 * Plot size 
 * Buffer size 
 * Buckets 
@@ -50,10 +53,15 @@ For each file it parses as much as it can find of the following (I imagine I'm n
 * Stripe size 
 * Start date 
 * Phase 1 duration 
+* Phase 1 CPU 
 * Phase 2 duration 
+* Phase 2 CPU 
 * Phase 3 duration 
+* Phase 3 CPU 
 * Phase 4 duration 
+* Phase 4 CPU 
 * Total time 
+* Total CPU 
 * Copy time
 * Plot filename
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ If the application does not run you may need to install the [Microsoft Visual C+
 
 ### What info does it parse?
 For each file it parses as much as it can find of the following (I imagine I'm not the only one who's had a plot interrupted):
-* Temp dir 1
-* Temp dir 2
 * Plot size 
 * Buffer size 
 * Buckets 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(chia-log-analysis VERSION 0.4)
+project(chia-log-analysis VERSION 0.3)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-project(chia-log-analysis VERSION 0.3)
+project(chia-log-analysis VERSION 0.5)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/src/InputHandler.cpp
+++ b/src/InputHandler.cpp
@@ -1,7 +1,3 @@
-// Handle the user input for the application
-// User can enter a few flags when calling the program from the CLI
-// Otherwise the handler prompts the user to enter necessary info
-
 #include <string>
 #include <vector>
 #include <iostream>

--- a/src/InputHandler.cpp
+++ b/src/InputHandler.cpp
@@ -1,3 +1,7 @@
+// Handle the user input for the application
+// User can enter a few flags when calling the program from the CLI
+// Otherwise the handler prompts the user to enter necessary info
+
 #include <string>
 #include <vector>
 #include <iostream>

--- a/src/Patterns.h
+++ b/src/Patterns.h
@@ -10,20 +10,22 @@ using namespace std;
 namespace patterns {
     const regex IGNORE = regex("^\tBucket"); // Start of lines to ignore
 
+    const regex TMP_DIR     = regex("^Starting plotting progress into .+ and (.+)");
+    const regex PLOT_ID     = regex("^ID: (.+)");
     const regex PLOT_SIZE   = regex("^Plot size is: (\\d+)");
     const regex BUFFER_SIZE = regex("^Buffer size is: (\\d+)MiB");
     const regex BUCKETS     = regex("^Using (\\d+) buckets");
     const regex THREADS     = regex("^Using (\\d+) threads of stripe size (\\d+)");
     const regex START_DATE  = regex("^Starting phase 1/4: Forward Propagation into tmp files\\.\\.\\. (.+)");
-    const regex PHASE_1     = regex("^Time for phase 1 = (\\d+\\.\\d+) seconds");
-    const regex PHASE_2     = regex("^Time for phase 2 = (\\d+\\.\\d+) seconds");
-    const regex PHASE_3     = regex("^Time for phase 3 = (\\d+\\.\\d+) seconds");
-    const regex PHASE_4     = regex("^Time for phase 4 = (\\d+\\.\\d+) seconds");
-    const regex TOTAL_TIME  = regex("^Total time = (\\d+\\.\\d+) seconds");
+    const regex PHASE_1     = regex("^Time for phase 1 = (\\d+\\.\\d+) seconds. CPU \\((\\d+\\.\\d+%)\\)");
+    const regex PHASE_2     = regex("^Time for phase 2 = (\\d+\\.\\d+) seconds. CPU \\((\\d+\\.\\d+%)\\)");
+    const regex PHASE_3     = regex("^Time for phase 3 = (\\d+\\.\\d+) seconds. CPU \\((\\d+\\.\\d+%)\\)");
+    const regex PHASE_4     = regex("^Time for phase 4 = (\\d+\\.\\d+) seconds. CPU \\((\\d+\\.\\d+%)\\)");
+    const regex TOTAL_TIME  = regex("^Total time = (\\d+\\.\\d+) seconds. CPU \\((\\d+\\.\\d+%)\\)");
     const regex COPY_TIME   = regex("^Copy time = (\\d+\\.\\d+) seconds");
     const regex FILENAME    = regex("^Renamed final file from \".+\" to (\".+\")");
 
-    const int NUM_SEARCHES = 12; // Number of patterns minus the ignore pattern
+    const int NUM_SEARCHES = 14; // Number of patterns minus the ignore pattern
 }
 
 #endif /* PATTERNS_H */

--- a/src/Patterns.h
+++ b/src/Patterns.h
@@ -10,7 +10,6 @@ using namespace std;
 namespace patterns {
     const regex IGNORE = regex("^\tBucket"); // Start of lines to ignore
 
-    const regex PLOT_DIRS   = regex("^Starting plotting progress into temporary dirs: ([[:print:]]+) and ([[:print:]]+)$");
     const regex PLOT_SIZE   = regex("^Plot size is: (\\d+)");
     const regex BUFFER_SIZE = regex("^Buffer size is: (\\d+)MiB");
     const regex BUCKETS     = regex("^Using (\\d+) buckets");
@@ -24,7 +23,7 @@ namespace patterns {
     const regex COPY_TIME   = regex("^Copy time = (\\d+\\.\\d+) seconds");
     const regex FILENAME    = regex("^Renamed final file from \".+\" to (\".+\")");
 
-    const int NUM_SEARCHES = 13; // Number of patterns minus the ignore pattern
+    const int NUM_SEARCHES = 12; // Number of patterns minus the ignore pattern
 }
 
 #endif /* PATTERNS_H */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 // Chia Log Analysis by Drew M. Johnson
 // Authored 4/11/2021
-// Last updated 5/10/2021
+// Last updated 4/29/2021
 //
 // This program prompts the user for two file locations if not provided:
 //      1) The location to read Chia plotter logs from
@@ -35,8 +35,6 @@ int main(int argc, char* argv[]) {
     if (out_file.is_open()) {
         if (filesystem::file_size(out_filename) == 0) {
             out_file << 
-                "Temp dir 1," << 
-                "Temp dir 2," << 
                 "Plot size," << 
                 "Buffer size," << 
                 "Buckets," << 
@@ -70,10 +68,7 @@ int main(int argc, char* argv[]) {
                         // "\tBucket" and we don't care about them so just skip
                         // these lines
                         continue;
-                    } else if (!found_flags[ff_i] && regex_search(current_line, match, patterns::PLOT_DIRS)) {
-                        out_file << match.str(1) << "," << match.str(2) << ",";
-                        found_flags[ff_i] = true;
-                    } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::PLOT_SIZE)) {
+                    } else if (!found_flags[ff_i] && regex_search(current_line, match, patterns::PLOT_SIZE)) {
                         out_file << match.str(1) << ",";
                         found_flags[ff_i] = true;
                     } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::BUFFER_SIZE)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,9 @@ int main(int argc, char* argv[]) {
     if (out_file.is_open()) {
         if (filesystem::file_size(out_filename) == 0) {
             out_file << 
+                "Filename," << 
+            	"Tmp Directory," << 
+		        "Plot ID," << 
                 "Plot size," << 
                 "Buffer size," << 
                 "Buckets," << 
@@ -42,10 +45,15 @@ int main(int argc, char* argv[]) {
                 "Stripe size," << 
                 "Start date," << 
                 "Phase 1 duration," << 
+                "Phase 1 CPU," <<
                 "Phase 2 duration," << 
+                "Phase 2 CPU," <<
                 "Phase 3 duration," << 
+                "Phase 3 CPU," <<
                 "Phase 4 duration," << 
+                "Phase 4 CPU,"
                 "Total time," << 
+                "Total CPU," <<                 
                 "Copy time," << 
                 "Plot filename," << 
                 endl;
@@ -56,9 +64,12 @@ int main(int argc, char* argv[]) {
             if (in_file.is_open()) {
                 smatch match;
                 bool found_flags[patterns::NUM_SEARCHES] = {false};
+                out_file << current.path() << ",";
                 while (getline(in_file, current_line)) {
 
                     size_t ff_i = 0; // found_flags iterator
+
+                     
 
                     // Perform regular expression searches for all the key info 
                     // we need, skipping searches that have already hit once to 
@@ -68,7 +79,13 @@ int main(int argc, char* argv[]) {
                         // "\tBucket" and we don't care about them so just skip
                         // these lines
                         continue;
-                    } else if (!found_flags[ff_i] && regex_search(current_line, match, patterns::PLOT_SIZE)) {
+                    } else if (!found_flags[ff_i] && regex_search(current_line, match, patterns::TMP_DIR)) {
+                        out_file << match.str(1) << ",";
+                        found_flags[ff_i] = true;
+                    } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::PLOT_ID)) {
+                        out_file << match.str(1) << ",";
+                        found_flags[ff_i] = true;
+                    } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::PLOT_SIZE)) {
                         out_file << match.str(1) << ",";
                         found_flags[ff_i] = true;
                     } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::BUFFER_SIZE)) {
@@ -84,19 +101,19 @@ int main(int argc, char* argv[]) {
                         out_file << match.str(1) << ",";
                         found_flags[ff_i] = true;
                     } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::PHASE_1)) {
-                        out_file << match.str(1) << ",";
+                        out_file << match.str(1) << "," << match.str(2) << ",";
                         found_flags[ff_i] = true;
                     } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::PHASE_2)) {
-                        out_file << match.str(1) << ",";
+                        out_file << match.str(1) << "," << match.str(2) << ",";
                         found_flags[ff_i] = true;
                     } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::PHASE_3)) {
-                        out_file << match.str(1) << ",";
+                        out_file << match.str(1) << "," << match.str(2) << ",";
                         found_flags[ff_i] = true;
                     } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::PHASE_4)) {
-                        out_file << match.str(1) << ",";
+                        out_file << match.str(1) << "," << match.str(2) << ",";
                         found_flags[ff_i] = true;
                     } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::TOTAL_TIME)) {
-                        out_file << match.str(1) << ",";
+                        out_file << match.str(1) << "," << match.str(2) << ",";
                         found_flags[ff_i] = true;
                     } else if (!found_flags[++ff_i] && regex_search(current_line, match, patterns::COPY_TIME)) {
                         out_file << match.str(1) << ",";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 // Chia Log Analysis by Drew M. Johnson
 // Authored 4/11/2021
-// Last updated 4/29/2021
+// Last updated 5/13/2021
 //
 // This program prompts the user for two file locations if not provided:
 //      1) The location to read Chia plotter logs from
@@ -36,8 +36,8 @@ int main(int argc, char* argv[]) {
         if (filesystem::file_size(out_filename) == 0) {
             out_file << 
                 "Filename," << 
-            	"Tmp Directory," << 
-		        "Plot ID," << 
+                "Temp Dir 1," << 
+                "Plot ID," << 
                 "Plot size," << 
                 "Buffer size," << 
                 "Buckets," << 
@@ -53,7 +53,7 @@ int main(int argc, char* argv[]) {
                 "Phase 4 duration," << 
                 "Phase 4 CPU,"
                 "Total time," << 
-                "Total CPU," <<                 
+                "Total CPU," << 
                 "Copy time," << 
                 "Plot filename," << 
                 endl;
@@ -68,8 +68,6 @@ int main(int argc, char* argv[]) {
                 while (getline(in_file, current_line)) {
 
                     size_t ff_i = 0; // found_flags iterator
-
-                     
 
                     // Perform regular expression searches for all the key info 
                     // we need, skipping searches that have already hit once to 


### PR DESCRIPTION
Hello! 

At your discretion and convenience please merge the following changes:
- Bump version to 0.5.
- Add log's filename, unique plot ID, and per-phase/total CPU utilization to CSV output.
- Default to only providing tmpdir1, or if tmpdir2 exists, tmpdir2. 

Two tmpdirs are rarely used in practice and are only recommended for phase 1/2 in ramdisk, which is unlikely on contemporary hardware (200+ GB of ram necessary per plot).